### PR TITLE
updated collisionbox for Minetest 5.x

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -32,7 +32,7 @@ local function unwatching(name)
 		watcher:set_properties({
 			visual_size = {x = 1, y = 1},
 			makes_footstep_sound = true,
-			collisionbox = {-0.3, -1, -0.3, 0.3, 1, 0.3}
+			collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3}
 		})
 
 		if not privs.interact and privs.watch == true then


### PR DESCRIPTION
After leaving the spectator mode in Minetest 5.x, the collisionbox isn't the right size and at the right place.
I simply changed the values of the collisionbox to match the vanilla ones.

A better solution would be to get the current size of the collisionbox when the player enter the spectator mode, store them, and use those when leaving that mode.
This would make the mod more compatible with other mods that changes the player's size.